### PR TITLE
Use Ethereum personal_sign isntead of JWT sign

### DIFF
--- a/references.markdown
+++ b/references.markdown
@@ -18,8 +18,10 @@ layout: default
 10. <span id="ref-10"></span> [Wikipedia - Challenge–response authentication](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication)
 11. <span id="ref-11"></span> [RFC-1994 - PPP Challenge Handshake Authentication Protocol (CHAP)](https://tools.ietf.org/html/rfc1994)
 12. <span id="ref-12"></span> [Verifiable Credentials JSON Schema Specification](https://w3c-ccg.github.io/vc-json-schemas/)
-12. <span id="ref-13"></span> [The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)
-13. <span id="ref-14"></span> [HTTP Authentication Scheme Registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml)
+13. <span id="ref-13"></span> [The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)
+14. <span id="ref-14"></span> [HTTP Authentication Scheme Registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml)
+15. <span id="ref-15"></span> [EIP-155 - Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155)
+16. <span id="ref-16"></span> [EIP-191 - Signed Data Standard](https://eips.ethereum.org/EIPS/eip-191)
 
 <script type="text/javascript">
   if (window.location.hash) {

--- a/ssi/specs/did-auth.markdown
+++ b/ssi/specs/did-auth.markdown
@@ -80,7 +80,7 @@ Requiring information to the user is OPTIONAL, it depends on the service needs. 
   Verification code: <challenge>
   My credentials are: <array of JWT credentials separated by commas>
   ```
-  where `<web domain` is the site DNS domain and ` <array of JWT credentials>` is the selective disclosure and is set if `sdr` was asked*. For example
+  where `<web domain` is the site DNS domain and `<array of JWT credentials>` is the selective disclosure (which is set if `sdr` was asked*). For example
   ```
   Login to taringa.net - Fri Nov 13 2020 16:01:28
   Verification code: 4531

--- a/ssi/specs/did-auth.markdown
+++ b/ssi/specs/did-auth.markdown
@@ -74,22 +74,20 @@ Requiring information to the user is OPTIONAL, it depends on the service needs. 
 1. _Client_ sends `POST /request-signup { did }` to _Service_, where `did` is _User_'s DID
 2. _Service_ creates a random deterministic* _challenge_. Responds with `{ challenge, sdr? }` were `sdr?` is the OPTIONAL [selective disclosure request](#request) defined by the _Service_. The `sdr` MUST be sent in a signed JWT format.
 3. If `sdr`, _Client_ obtains the information required from the user's desired service or platform (for example, from the [RIF Data Vault]({{ site.baseurl }}/data-vault)), and builds a [selective disclosure](#response) (response)
-4. _Client_ builds a JWT with the following payload:
-  ```javascript
-  {
-    iss: `${userDid}`,
-    sub: `${serviceDid}`,
-    aud: `${serviceUrl}`,
-    exp: `${now + 2 min}`,
-    nbf: `${now}`,
-    iat: `${now}`,
-    challenge: `${receivedChallenge}`,
-    sd?: `${builtSd}`
-  }
+4. _Client_ signs a message with  the following format using `personal_sign` as per EIP-191{% include ref.html id="15" %} and EIP-155{% include ref.html id="6" %}:
   ```
-  where `sd` is the selective disclosure and is set if `sdr` was asked.
-5. _User_ signs the JWT with the DID controller's private key. _Client_ sends  `POST /signup { response: jwt }` to _Service_
-6. _Service_ verifies JWT signature, compares by equality the received `challenge` with the requested one, and performs business logic over the `sdr`. If business logic is successful, it logs the user in by creating an _access token_ and a _refresh token_:
+  Login to <web domain> - <Date and time in UTC format>
+  Verification code: <challenge>
+  My credentials are: <array of JWT credentials separated by commas>
+  ```
+  where `<web domain` is the site DNS domain and ` <array of JWT credentials>` is the selective disclosure and is set if `sdr` was asked*. For example
+  ```
+  Login to taringa.net - Fri Nov 13 2020 16:01:28
+  Verification code: 4531
+  My credentials are: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwicm9sZSI6IlJJRiBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjpyc2s6MHg0Y2MxNzc0MjI2NDNjMzgxNGE5ZThhNzY1NDk4NTIxYzUyMDRmMTExIiwiaWF0IjoxNTE2MjM5MDIyfQ.3sauMI60RVqc1QrvooZnNnmjAMiHj4qt5ZSEYhOULvA,eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwic2tpbGxzIjoiQmxvY2tjaGFpbiIsImlzcyI6ImRpZDpldGhyOnJzazoweDRjYzE3NzQyMjY0M2MzODE0YTllOGE3NjU0OTg1MjFjNTIwNGYxMTEiLCJpYXQiOjE1MTYyMzkwMjJ9.SgPPVFj0lU9E_dq_aPOmrf_CZljNh1ZaEhAufAbIgFY
+  ```
+5. _User_ signs the message with the DID controller's private key. _Client_ sends  `POST /signup { response: signature }` to _Service_
+6. _Service_ verifies message signature, compares by equality the received `challenge` with the requested one, validates the given date and domain, and performs business logic over the selective disclosure. If business logic is successful, it logs the user in by creating an _access token_ and a _refresh token_:
   - The _access token_ is a JWT signed with the service controller DID's private key. The JWT MUST have, at least, the following payload:
     ```javascript
     {
@@ -107,6 +105,8 @@ Requiring information to the user is OPTIONAL, it depends on the service needs. 
     ```javascript
     { accessToken, refreshToken }
     ```
+
+> *The credential format is not friendly for the user: they cannot understand what they are signing. Future work will research on finding a more user-oriented form to display the JWTs but with current technology this is what we can do. Ideally EIP-712 could be used to show display JWTs in user-oriented form.
 
 See [authenticating requests](#authenticating-requests) to understand how to user _access_ and _refresh_ tokens.
 
@@ -171,21 +171,14 @@ Services should use _login_ after [registering](#register) users. This means the
 
 1. _Client_ sends `POST /request-auth { did }` to _Service_, where `did` is _User_'s DID
 2. _Service_ creates a random deterministic* _challenge_ to send to _Client_ and responds with `{ challenge }`.
-3. _Client_ receives _Service_'s `challenge` and creates a JWT{% include ref.html id="1" %} with the following payload:
-  ```javascript
-  {
-    iss: `${userDid}`,
-    sub: `${serviceDid}`,
-    aud: `${serviceUrl}`,
-    exp: `${now + 2 min}`,
-    nbf: `${now}`,
-    iat: `${now}`,
-    challenge: `${receivedChallenge}`,
-  }
+3. _Client_ signs a message with  the following format using `personal_sign` as per EIP-191{% include ref.html id="15" %} and EIP-155{% include ref.html id="6" %}:
+  ```
+  Login to <web domain> - <Date and time in UTC format>
+  Verification code: <challenge>
   ```
   _Client_ prompts the _User_ to sign it with DID controller's private key.
-5. _Client_ sends  `POST /auth { response: jwt }` with the just signed JWT.
-6. _Service_ verifies JWT signature, checks if the received `challenge` matches the requested one and, if necessary, performs business logic over the `did` and the information related to it saved by the _Service_. If it is a valid user, it creates an _access token_ and a _refresh token_ - see ([register](#register) to understand required token JWT payload format)
+5. _Client_ sends  `POST /auth { response: signature }` with the just signed JWT.
+6. _Service_ verifies message signature, compares by equality the received `challenge` with the requested one, validates the given date and domain and, if necessary, performs business logic over the `did` and the information related to it saved by the _Service_. If it is a valid user, it creates an _access token_ and a _refresh token_ - see ([register](#register) to understand required token JWT payload format)
 
 See [authenticating requests](#authenticating-requests) to understand how to user _access_ and _refresh_ tokens.
 

--- a/ssi/specs/did-auth.markdown
+++ b/ssi/specs/did-auth.markdown
@@ -171,7 +171,7 @@ Services should use _login_ after [registering](#register) users. This means the
 
 1. _Client_ sends `POST /request-auth { did }` to _Service_, where `did` is _User_'s DID
 2. _Service_ creates a random deterministic* _challenge_ to send to _Client_ and responds with `{ challenge }`.
-3. _Client_ signs a message with  the following format using `personal_sign` as per EIP-191{% include ref.html id="15" %} and EIP-155{% include ref.html id="6" %}:
+3. _Client_ signs a message with  the following format using `personal_sign` as per EIP-191{% include ref.html id="16" %} and EIP-155{% include ref.html id="15" %}:
   ```
   Login to <web domain> - <Date and time in UTC format>
   Verification code: <challenge>

--- a/ssi/specs/did-auth.markdown
+++ b/ssi/specs/did-auth.markdown
@@ -74,7 +74,7 @@ Requiring information to the user is OPTIONAL, it depends on the service needs. 
 1. _Client_ sends `POST /request-signup { did }` to _Service_, where `did` is _User_'s DID
 2. _Service_ creates a random deterministic* _challenge_. Responds with `{ challenge, sdr? }` were `sdr?` is the OPTIONAL [selective disclosure request](#request) defined by the _Service_. The `sdr` MUST be sent in a signed JWT format.
 3. If `sdr`, _Client_ obtains the information required from the user's desired service or platform (for example, from the [RIF Data Vault]({{ site.baseurl }}/data-vault)), and builds a [selective disclosure](#response) (response)
-4. _Client_ signs a message with  the following format using `personal_sign` as per EIP-191{% include ref.html id="15" %} and EIP-155{% include ref.html id="6" %}:
+4. _Client_ signs a message with  the following format using `personal_sign` as per EIP-191{% include ref.html id="16" %} and EIP-155{% include ref.html id="15" %}:
   ```
   Login to <web domain> - <Date and time in UTC format>
   Verification code: <challenge>

--- a/ssi/specs/did-auth.markdown
+++ b/ssi/specs/did-auth.markdown
@@ -76,55 +76,59 @@ Requiring information to the user is OPTIONAL, it depends on the service needs. 
 3. If `sdr`, _Client_ obtains the information required from the user's desired service or platform (for example, from the [RIF Data Vault]({{ site.baseurl }}/data-vault)), and builds a [selective disclosure](#response) (response)
 4. _Client_ pormpts user to sign a message with the following format using `personal_sign` as per EIP-191{% include ref.html id="16" %} and EIP-155{% include ref.html id="15" %}:
   ```
-  Login to <web domain> - <Date and time in UTC format>
-  Verification code: <challenge>
-  My credentials are: <array of JWT credentials separated by commas>
+Login to <web domain> - <Date and time in UTC format>
+Verification code: <challenge>
+My credentials are: <array of JWT credentials separated by commas>
   ```
   where `<web domain>` is the site DNS domain and `<array of JWT credentials>` is the selective disclosure (which is set if `sdr` was asked*). For example
   ```
-  Login to taringa.net - Fri Nov 13 2020 16:01:28
-  Verification code: 4531
-  My credentials are: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwicm9sZSI6IlJJRiBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjpyc2s6MHg0Y2MxNzc0MjI2NDNjMzgxNGE5ZThhNzY1NDk4NTIxYzUyMDRmMTExIiwiaWF0IjoxNTE2MjM5MDIyfQ.3sauMI60RVqc1QrvooZnNnmjAMiHj4qt5ZSEYhOULvA,eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwic2tpbGxzIjoiQmxvY2tjaGFpbiIsImlzcyI6ImRpZDpldGhyOnJzazoweDRjYzE3NzQyMjY0M2MzODE0YTllOGE3NjU0OTg1MjFjNTIwNGYxMTEiLCJpYXQiOjE1MTYyMzkwMjJ9.SgPPVFj0lU9E_dq_aPOmrf_CZljNh1ZaEhAufAbIgFY
+Login to taringa.net - Fri Nov 13 2020 16:01:28
+Verification code: 4531
+My credentials are: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwicm9sZSI6IlJJRiBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjpyc2s6MHg0Y2MxNzc0MjI2NDNjMzgxNGE5ZThhNzY1NDk4NTIxYzUyMDRmMTExIiwiaWF0IjoxNTE2MjM5MDIyfQ.3sauMI60RVqc1QrvooZnNnmjAMiHj4qt5ZSEYhOULvA,eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwic2tpbGxzIjoiQmxvY2tjaGFpbiIsImlzcyI6ImRpZDpldGhyOnJzazoweDRjYzE3NzQyMjY0M2MzODE0YTllOGE3NjU0OTg1MjFjNTIwNGYxMTEiLCJpYXQiOjE1MTYyMzkwMjJ9.SgPPVFj0lU9E_dq_aPOmrf_CZljNh1ZaEhAufAbIgFY
   ```
 5. _User_ signs the message with the DID controller's private key. _Client_ sends to _Service_
   ```
-  POST /signup {
-    did: <signer's DID>,
-    sig: <message signature>,
-    timestamp: <Date and time in UTC format>,
-    credentials: <array of JWT credentials> }
+POST /signup {
+  did: <signer's DID>,
+  sig: <message signature>,
+  timestamp: <Date and time in UTC format>,
+  credentials: <array of JWT credentials> 
+}
   ```
   For the given example it is
   ```json
-  { "did": "did:ethr:rsk:0xa53...dec",
-    "sig": "...",
-    "timestamp": "Fri Nov 13 2020 16:01:28",
-    "credentials": [
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwicm9sZSI6IlJJRiBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjpyc2s6MHg0Y2MxNzc0MjI2NDNjMzgxNGE5ZThhNzY1NDk4NTIxYzUyMDRmMTExIiwiaWF0IjoxNTE2MjM5MDIyfQ.3sauMI60RVqc1QrvooZnNnmjAMiHj4qt5ZSEYhOULvA,eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwic2tpbGxzIjoiQmxvY2tjaGFpbiIsImlzcyI6ImRpZDpldGhyOnJzazoweDRjYzE3NzQyMjY0M2MzODE0YTllOGE3NjU0OTg1MjFjNTIwNGYxMTEiLCJpYXQiOjE1MTYyMzkwMjJ9.SgPPVFj0lU9E_dq_aPOmrf_CZljNh1ZaEhAufAbIgFY" ] }
+{ 
+  "did": "did:ethr:rsk:0xa53...dec",
+  "sig": "...",
+  "timestamp": "Fri Nov 13 2020 16:01:28",
+  "credentials": [
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwicm9sZSI6IlJJRiBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjpyc2s6MHg0Y2MxNzc0MjI2NDNjMzgxNGE5ZThhNzY1NDk4NTIxYzUyMDRmMTExIiwiaWF0IjoxNTE2MjM5MDIyfQ.3sauMI60RVqc1QrvooZnNnmjAMiHj4qt5ZSEYhOULvA,eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwic2tpbGxzIjoiQmxvY2tjaGFpbiIsImlzcyI6ImRpZDpldGhyOnJzazoweDRjYzE3NzQyMjY0M2MzODE0YTllOGE3NjU0OTg1MjFjNTIwNGYxMTEiLCJpYXQiOjE1MTYyMzkwMjJ9.SgPPVFj0lU9E_dq_aPOmrf_CZljNh1ZaEhAufAbIgFY"
+  ]
+}
   ```
 6. _Service_ receives the `response` and recovers the signer against this message (_Service_ needs the _User_'s DID to fetch the expected challenge):
   ```
-  Login to {SERVICE_EXPECTED_DOMAIN} - {response.timestamp}
-  Verification code: {EXPECTED_CHALLENGE}
-  My credentials are: {response.credentials.join(',')}
+Login to {SERVICE_EXPECTED_DOMAIN} - {response.timestamp}
+Verification code: {EXPECTED_CHALLENGE}
+My credentials are: {response.credentials.join(',')}
   ```
   Then checks message signer matches `response.did`'s address, and performs business logic over the selective disclosure. If business logic is successful, it logs the user in by creating an _access token_ and a _refresh token_:
   - The _access token_ is a JWT signed with the service controller DID's private key. The JWT MUST have, at least, the following payload:
     ```javascript
-    {
-      iss: `${serviceDid}`,
-      aud: `${serviceUrl}`,
-      sub: `${userDid}`,
-      exp: `${now + 10 min}`, // should be shorter than 15 minutes
-      nbf: `${now}`,
-      iat: `${now}`
-    }
+{
+  iss: `${serviceDid}`,
+  aud: `${serviceUrl}`,
+  sub: `${userDid}`,
+  exp: `${now + 10 min}`, // should be shorter than 15 minutes
+  nbf: `${now}`,
+  iat: `${now}`
+}
     ```
     Other claims could be useful for storing user metadata and other use case related information.
   - The _refresh token_ is an opaque string (could be a random one) that will be associated to user session data in the server. It has a long expiration
   - The HTTP status is 200 and the body is
     ```javascript
-    { accessToken, refreshToken }
+{ accessToken, refreshToken }
     ```
 
 > *The credential format is not friendly for the user: they cannot understand what they are signing. Future work will research on finding a more user-oriented form to display the JWTs but with current technology this is what we can do. Ideally EIP-712 could be used to show display JWTs in user-oriented form.
@@ -194,22 +198,23 @@ Services should use _login_ after [registering](#register) users. This means the
 2. _Service_ creates a random deterministic* _challenge_ to send to _Client_ and responds with `{ challenge }`.
 3. _Client_ signs a message with  the following format using `personal_sign` as per EIP-191{% include ref.html id="16" %} and EIP-155{% include ref.html id="15" %}:
   ```
-  Login to <web domain> - <Date and time in UTC format>
-  Verification code: <challenge>
+Login to <web domain> - <Date and time in UTC format>
+Verification code: <challenge>
   ```
   _Client_ prompts the _User_ to sign it with DID controller's private key.
 5. _Client_ sends  to _Service_
   ```
-  POST /auth {
-    did: <signer's DID>,
-    sig: <message signature>,
-    timestamp: <Date and time in UTC format> }
+POST /auth {
+  did: <signer's DID>,
+  sig: <message signature>,
+  timestamp: <Date and time in UTC format>
+}
   ```
 6. _Service_ receives the `response` and recovers the signer against this message:
   ```
-  Login to {SERVICE_EXPECTED_DOMAIN} - {response.timestamp}
-  Verification code: {EXPECTED_CHALLENGE}
-  My credentials are: {response.credentials.join(',')}
+Login to {SERVICE_EXPECTED_DOMAIN} - {response.timestamp}
+Verification code: {EXPECTED_CHALLENGE}
+My credentials are: {response.credentials.join(',')}
   ```
   Then checks message signer matches `response.did`'s address. If necessary, performs business logic over the `did` and the information related to it saved by the _Service_. If it is a valid user, it creates an _access token_ and a _refresh token_ - see ([register](#register) to understand required token JWT payload format)
 
@@ -228,7 +233,7 @@ After the user is registered and has logged in (meaning the user is holding an _
 9. If _Client_ receives HTTP 401, sends `POST /refresh-token` to _Service_ including the _refresh token_. See [how to send refresh tokens](#refresh-token).
 10. _Service_ validates the _refresh token_ and the current session status. If valid, issues new _access token_ (with same data but new expiration), invalidates the received _refresh token_ and issues a new one. The HTTP status is 200 and the body is
   ```javascript
-  { accessToken, refreshToken }
+{ accessToken, refreshToken }
   ```
 11. _Client_ authenticates next HTTP requests using the received _access token_.
 12. _Service_ authorizes the request.
@@ -321,12 +326,12 @@ It must be placed in the body of the request as a `refreshToken` field.
 For example:
 
 ```
-  POST /refresh-token HTTP/1.1
-  Host: server.example.com
+POST /refresh-token HTTP/1.1
+Host: server.example.com
 
-  {
-    refreshToken: 'theRefreshToken'
-  }
+{
+  refreshToken: 'theRefreshToken'
+}
 ```
 
 ###### Cookie

--- a/ssi/specs/did-auth.markdown
+++ b/ssi/specs/did-auth.markdown
@@ -76,13 +76,13 @@ Requiring information to the user is OPTIONAL, it depends on the service needs. 
 3. If `sdr`, _Client_ obtains the information required from the user's desired service or platform (for example, from the [RIF Data Vault]({{ site.baseurl }}/data-vault)), and builds a [selective disclosure](#response) (response)
 4. _Client_ pormpts user to sign a message with the following format using `personal_sign` as per EIP-191{% include ref.html id="16" %} and EIP-155{% include ref.html id="15" %}:
   ```
-Login to <web domain> - <Date and time in UTC format>
+Login to <web domain>
 Verification code: <challenge>
 My credentials are: <array of JWT credentials separated by commas>
   ```
   where `<web domain>` is the site DNS domain and `<array of JWT credentials>` is the selective disclosure (which is set if `sdr` was asked*). For example
   ```
-Login to taringa.net - Fri Nov 13 2020 16:01:28
+Login to taringa.net
 Verification code: 4531
 My credentials are: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwicm9sZSI6IlJJRiBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjpyc2s6MHg0Y2MxNzc0MjI2NDNjMzgxNGE5ZThhNzY1NDk4NTIxYzUyMDRmMTExIiwiaWF0IjoxNTE2MjM5MDIyfQ.3sauMI60RVqc1QrvooZnNnmjAMiHj4qt5ZSEYhOULvA,eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwic2tpbGxzIjoiQmxvY2tjaGFpbiIsImlzcyI6ImRpZDpldGhyOnJzazoweDRjYzE3NzQyMjY0M2MzODE0YTllOGE3NjU0OTg1MjFjNTIwNGYxMTEiLCJpYXQiOjE1MTYyMzkwMjJ9.SgPPVFj0lU9E_dq_aPOmrf_CZljNh1ZaEhAufAbIgFY
   ```
@@ -91,7 +91,6 @@ My credentials are: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjp
 POST /signup {
   did: <signer's DID>,
   sig: <message signature>,
-  timestamp: <Date and time in UTC format>,
   credentials: <array of JWT credentials> 
 }
   ```
@@ -100,7 +99,6 @@ POST /signup {
 { 
   "did": "did:ethr:rsk:0xa53...dec",
   "sig": "...",
-  "timestamp": "Fri Nov 13 2020 16:01:28",
   "credentials": [
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwicm9sZSI6IlJJRiBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjpyc2s6MHg0Y2MxNzc0MjI2NDNjMzgxNGE5ZThhNzY1NDk4NTIxYzUyMDRmMTExIiwiaWF0IjoxNTE2MjM5MDIyfQ.3sauMI60RVqc1QrvooZnNnmjAMiHj4qt5ZSEYhOULvA,eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjpyc2s6MHhjMmE0MWY3NmNhY2ZhOTMzYzM0OTY5NzdmMjE2MDk0NGVmOGMyZGUzIiwic2tpbGxzIjoiQmxvY2tjaGFpbiIsImlzcyI6ImRpZDpldGhyOnJzazoweDRjYzE3NzQyMjY0M2MzODE0YTllOGE3NjU0OTg1MjFjNTIwNGYxMTEiLCJpYXQiOjE1MTYyMzkwMjJ9.SgPPVFj0lU9E_dq_aPOmrf_CZljNh1ZaEhAufAbIgFY"
   ]
@@ -108,7 +106,7 @@ POST /signup {
   ```
 6. _Service_ receives the `response` and recovers the signer against this message (_Service_ needs the _User_'s DID to fetch the expected challenge):
   ```
-Login to {SERVICE_EXPECTED_DOMAIN} - {response.timestamp}
+Login to {SERVICE_EXPECTED_DOMAIN}
 Verification code: {EXPECTED_CHALLENGE}
 My credentials are: {response.credentials.join(',')}
   ```
@@ -198,7 +196,7 @@ Services should use _login_ after [registering](#register) users. This means the
 2. _Service_ creates a random deterministic* _challenge_ to send to _Client_ and responds with `{ challenge }`.
 3. _Client_ signs a message with  the following format using `personal_sign` as per EIP-191{% include ref.html id="16" %} and EIP-155{% include ref.html id="15" %}:
   ```
-Login to <web domain> - <Date and time in UTC format>
+Login to <web domain>
 Verification code: <challenge>
   ```
   _Client_ prompts the _User_ to sign it with DID controller's private key.
@@ -206,13 +204,12 @@ Verification code: <challenge>
   ```
 POST /auth {
   did: <signer's DID>,
-  sig: <message signature>,
-  timestamp: <Date and time in UTC format>
+  sig: <message signature>
 }
   ```
 6. _Service_ receives the `response` and recovers the signer against this message:
   ```
-Login to {SERVICE_EXPECTED_DOMAIN} - {response.timestamp}
+Login to {SERVICE_EXPECTED_DOMAIN}
 Verification code: {EXPECTED_CHALLENGE}
 My credentials are: {response.credentials.join(',')}
   ```


### PR DESCRIPTION
Motivation: the message displayed to the user when asking to sign a JWT is unintelligible for the user. Modifying the signature requested to the user for a string message improves much better for user-facing wallets and keeps same security level.